### PR TITLE
feat: Added a startup setting to remove tile transition effects.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,16 @@
     "Lua.diagnostics.disable": [
         "lowercase-global"
     ],
-    "Lua.runtime.version": "Lua 5.2"
+    "Lua.runtime.version": "Lua 5.2",
+    "factorio.versions": [
+        {
+            "name": "Steam",
+            "factorioPath": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Factorio\\bin\\x64\\factorio.exe",
+            "active": true
+        }
+    ],
+    "Lua.workspace.userThirdParty": [
+        "c:\\Users\\aaron\\AppData\\Roaming\\Code\\User\\workspaceStorage\\2c0db3f7f6703ee2242e9402900b5888\\justarandomgeek.factoriomod-debug\\sumneko-3rd"
+    ],
+    "Lua.workspace.checkThirdParty": "ApplyInMemory"
 }

--- a/locale/en/factorissimo2.cfg
+++ b/locale/en/factorissimo2.cfg
@@ -106,6 +106,7 @@ give-lost-factory-buildings=Gives you all picked-up factory buildings in item fo
 
 [mod-setting-name]
 Factorissimo2-prevent-spidertron-travel=Prevent spidertron travel
+Factorissimo2-disable-new-tile-effects=Disable new tile effects
 Factorissimo2-free-recursion=Free recursion
 Factorissimo2-hide-recursion=Hide recursion technologies
 Factorissimo2-hide-recursion-2=Hide recursion 2 technology
@@ -118,6 +119,7 @@ Factorissimo2-alt-graphics=Alt factory graphics
 
 [mod-setting-description]
 Factorissimo2-prevent-spidertron-travel=Prevent travel inside Factory buildings using Spidertrons or any Spider prototypes added by mods (may include helicopters, submarines, ect).
+Factorissimo2-disable-new-tile-effects=Disables the new tile effects added in 2.0, returning the factories to the cleaner edged 1.1 look.
 Factorissimo2-free-recursion=Allows you to build recursive factory setups even without researching any of the Recursion technologies.
 Factorissimo2-hide-recursion=Hides the Recursion 1 and 2 technologies, you will not be able to research them.
 Factorissimo2-hide-recursion-2=Hides the Recursion 2 technology, you will not be able to research it.

--- a/prototypes/tile.lua
+++ b/prototypes/tile.lua
@@ -10,6 +10,7 @@ local concrete_tile_build_sounds = table.deepcopy(data.raw["tile"]["concrete"].b
 
 local F = "__factorissimo-2-notnotmelon__"
 local alt_graphics = settings.startup["Factorissimo2-alt-graphics"].value
+local no_tile_transitions = settings.startup["Factorissimo2-disable-new-tile-effects"].value
 
 data:extend{{
 	type = "item-subgroup",
@@ -17,6 +18,30 @@ data:extend{{
 	order = "q",
 	group = "tiles"
 }}
+
+local function tile_transitions(tinfo)
+	if no_tile_transitions then	
+		return {
+			main = tinfo.pictures,
+			empty_transitions = true
+		}
+	else
+		return {
+			main = tinfo.pictures,
+			transition = {
+				transition_group = out_of_map_transition_group_id,
+	
+				background_layer_offset = 1,
+				background_layer_group = "zero",
+				offset_background_layer_by_tile_layer = true,
+	
+				spritesheet = "__factorissimo-2-notnotmelon__/graphics/tile/out-of-map-transition.png",
+				layout = tile_spritesheet_layout.transition_4_4_8_1_1,
+				overlay_enabled = false
+			}
+		}
+	end
+end
 
 local function make_tile(tinfo)
 	data:extend {{
@@ -26,20 +51,7 @@ local function make_tile(tinfo)
 		needs_correction = false,
 		collision_mask = tinfo.collision_mask,
 		layer = tinfo.layer or 50,
-		variants = {
-			main = tinfo.pictures,
-			transition = {
-				transition_group = out_of_map_transition_group_id,
-
-				background_layer_offset = 1,
-				background_layer_group = "zero",
-				offset_background_layer_by_tile_layer = true,
-
-				spritesheet = "__factorissimo-2-notnotmelon__/graphics/tile/out-of-map-transition.png",
-				layout = tile_spritesheet_layout.transition_4_4_8_1_1,
-				overlay_enabled = false
-			}
-		},
+		variants = tile_transitions(tinfo),
 		walking_speed_modifier = 1.4,
 		layer_group = "ground-artificial",
 		mined_sound = sounds.deconstruct_bricks(0.8),

--- a/settings.lua
+++ b/settings.lua
@@ -7,6 +7,13 @@ data:extend {
 		default_value = false,
 		order = "a-a",
 	},
+	{
+		type = "bool-setting",
+		name = "Factorissimo2-disable-new-tile-effects",
+		setting_type = "startup",
+		default_value = false,
+		order = "a-b",
+	},
 	-- Global
 	{
 		type = "bool-setting",


### PR DESCRIPTION
When checked, the setting will swap the tile transition effects off, returning the old 1.1 style crisp tile edges.

![image](https://github.com/user-attachments/assets/d2b17b46-061b-4052-b905-ca0a47d09966)
![image](https://github.com/user-attachments/assets/7cf0b47d-4be1-4da8-8e60-c153ce8b0c70)
