### PR TITLE
Fix agricultural towers not being placeable on Fulgora. For https://m…

### DIFF
--- a/prototypes/greenhouse.lua
+++ b/prototypes/greenhouse.lua
@@ -22,7 +22,7 @@ for _, tower in pairs(data.raw["agricultural-tower"]) do
     tower.surface_conditions = tower.surface_conditions or {}
     table.insert(tower.surface_conditions, {
         property = "solar-power",
-        min = 25
+        min = 1
     })
 end
 


### PR DESCRIPTION
Hiya @notnotmelon! Forking Factorissimo 3 for [this issue](https://mods.factorio.com/mod/fulgora-coralmium-agriculture/discussion/67ac39feb157e9845509d13a), basically my mod adds plants on Fulgora and Factorissimo 3's solar power surface condition prevents ag towers from being placed on Fulg.