### PR TITLE
compat: Fix crash with boblogistics

### DIFF
--- a/prototypes/roboport.lua
+++ b/prototypes/roboport.lua
@@ -71,6 +71,7 @@ data:extend {{
 local hidden_construction_robot = table.deepcopy(data.raw["construction-robot"]["construction-robot"])
 hidden_construction_robot.name = "factory-hidden-construction-robot"
 hidden_construction_robot.minable = nil
+hidden_construction_robot.next_upgrade = nil
 hidden_construction_robot.placeable_by = nil
 hidden_construction_robot.created_effect = {
     type = "direct",


### PR DESCRIPTION
I've just updated Bob's Logistics. One of the changes was setting `next_upgrade` on construction and logistic robots. Although the upgrade planner doesn't work on robots, this `next_upgrade` value can be read at run time by mods, allowing them to do interesting things.

When clearing an entity's `minable` property, `next_upgrade` should also be cleared.

https://lua-api.factorio.com/latest/prototypes/EntityPrototype.html#next_upgrade

> next_upgrade :: [EntityID](https://lua-api.factorio.com/latest/types/EntityID.html) optional 
> Name of the entity that will be automatically selected as the upgrade of this entity when using the [upgrade planner](https://wiki.factorio.com/Upgrade_planner) without configuration.
> This entity may not have "not-upgradable" flag set and **_must be minable_**.


Fixes #190
