### PR TITLE
fix: Deconstruction crash with unresearched roboport upgrade. Resolves https://github.com/notnotmelon/factorissimo-2-notnotmelon/issues/217

### DIFF
--- a/script/roboport/roboport.lua
+++ b/script/roboport/roboport.lua
@@ -305,6 +305,7 @@ factorissimo.build_roboport_upgrade = function(factory)
 end
 
 factorissimo.cleanup_factory_roboport_exterior_chest = function(factory)
+    if not factory.roboport_upgrade then return end
     factory.roboport_upgrade.item_request_proxies = {}
 
     local requester = factory.roboport_upgrade and factory.roboport_upgrade.requester and factory.roboport_upgrade.requester.valid and factory.roboport_upgrade.requester


### PR DESCRIPTION
Deconstructing a factory building without the roboport researched would cause a crash, as `factory.roboport_upgrade` isn't set.