### PR TITLE
fix: Fixes duplicate "-factory-floor" in surface name. Resolves https://github.com/notnotmelon/factorissimo-2-notnotmelon/issues/251

### DIFF
--- a/script/factory-buildings.lua
+++ b/script/factory-buildings.lua
@@ -219,7 +219,7 @@ local function which_void_surface_should_this_new_factory_be_placed_on(layout, b
 
     local surface = building.surface
     if surface.planet then
-        return (surface.planet.name .. "-factory-floor")
+        return (surface.planet.name .. "-factory-floor"):gsub("%-factory%-floor%-factory%-floor", "-factory-floor")
     end
 
     storage.next_factory_surface = storage.next_factory_surface + 1


### PR DESCRIPTION
Fixes #251 by preventing duplicate "-factory-floor-factory-floor" names in surfaces