### PR TITLE
Improve check by seeing if the Chest is full and skip checking items.

### DIFF
--- a/script/connections/chest.lua
+++ b/script/connections/chest.lua
@@ -200,6 +200,7 @@ local function balance_chests(outside_inv, inside_inv)
 end
 
 local function move_items_inwards(outside_inv, inside_inv)
+    if inside_inv.is_full() then return end
     for i = 1, #outside_inv do
         local stack = outside_inv[i]
         if stack.valid_for_read then
@@ -212,6 +213,7 @@ local function move_items_inwards(outside_inv, inside_inv)
 end
 
 local function move_items_outwards(outside_inv, inside_inv)
+    if outside_inv.is_full() then return end
     for i = 1, #inside_inv do
         local stack = inside_inv[i]
         if stack.valid_for_read then
@@ -222,6 +224,7 @@ local function move_items_outwards(outside_inv, inside_inv)
         end
     end
 end
+
 
 Chest.tick = function(conn)
     local outside = conn.outside


### PR DESCRIPTION
Why check if you able to move items if the direction of chest is already full. This saved me about 30ms spikes on my save of 500 chest connections.