### PR TITLE
Fix: use AmbientSound::planets instead of obsolete planet field

### DIFF
--- a/prototypes/space-location.lua
+++ b/prototypes/space-location.lua
@@ -108,12 +108,25 @@ local function update_surface_render_parameters(planet, factory_floor)
     end
 end
 
+local function music_matches_planet(music, planet_name)
+    if music.planets then
+        for _, name in pairs(music.planets) do
+            if name == planet_name then return true end
+        end
+    end
+    -- `AmbientSound::planet` was replaced by `planets` in Factorio 2.1.7 and became a hard
+    -- error in 2.1.13. Keep checking it for mods/base versions that still emit the old field.
+    if music.planet == planet_name then return true end
+    return music.track_type == "hero-track" and music.name:find(planet_name)
+end
+
 local function add_music(planet, factory_floor)
     for _, music in pairs(data.raw["ambient-sound"]) do
-        if music.planet == planet.name or (music.track_type == "hero-track" and music.name:find(planet.name)) then
+        if music_matches_planet(music, planet.name) then
             local new_music = table.deepcopy(music)
             new_music.name = music.name .. "-" .. factory_floor.name
-            new_music.planet = factory_floor.name
+            new_music.planet = nil
+            new_music.planets = {factory_floor.name}
             if new_music.track_type == "hero-track" then
                 new_music.track_type = "main-track"
                 new_music.weight = 10


### PR DESCRIPTION
## Summary
Fixes #287.

Factorio 2.1.7 replaced the `AmbientSound::planet` prototype field with the `planets` array (plus `surface_names`, `play_on_all_surfaces`, `exclude_planets`, `exclude_surface_names`). Factorio 2.1.13 turned the old `planet` field into a hard load error, which broke Factorissimo's `add_music` in `prototypes/space-location.lua` for anyone with a planet mod installed:

```
Failed to load mods: Error while loading ambient-sound prototype "vulcanus-3-hero-vulcanus-factory-floor" (ambient-sound): AmbientSound::planet is obsolete. Please use AmbientSound::planets in property tree at ROOT.ambient-sound.vulcanus-3-hero-vulcanus-factory-floor
Modifications: Factorissimo 3
```

- `music_matches_planet` now checks the new `music.planets` array (falling back to the legacy singular `music.planet` for mods/base versions that still emit it).
- Generated ambient-sound prototypes now set `planets = {factory_floor.name}` and clear `planet`, instead of writing to the obsolete `planet` field.

This matches the fix independently found and confirmed working by two users in #287.

## Test plan
- [ ] Load with a planet-adding mod (e.g. one adding Vulcanus hero tracks) on Factorio 2.1.13+ and confirm mods load without the `AmbientSound::planet is obsolete` error.
- [ ] Confirm factory-floor ambient tracks still play on the correct planet's factory floor.