### PR TITLE
fix: do not merge ambient sounds table if it's empty

### DIFF
--- a/prototypes/space-location.lua
+++ b/prototypes/space-location.lua
@@ -119,6 +119,7 @@ local function add_music(planet, factory_floor)
     end
 
     local new_musics = {}
+    local has_new_music = false
     for _, music in pairs(data.raw["ambient-sound"]) do
         if music_matches_planet(music) then
             local new_music = table.deepcopy(music)
@@ -129,9 +130,10 @@ local function add_music(planet, factory_floor)
                 new_music.weight = 10
             end
             table.insert(new_musics, new_music)
+            has_new_music = true
         end
     end
-    data:extend(new_musics)
+    if has_new_music then data:extend(new_musics) end
 end
 
 -- we need to copy all existing planets in order to create factory floors for them


### PR DESCRIPTION
Some modded planets, e.g. Tiber, doesn't have hero-track tracks.

For example, with [Factorio and Conquer: Tiberian Dawn](https://mods.factorio.com/mod/Factorio-Tiberium) enabled, I get this error:
<img width="1262" height="500" alt="image" src="https://github.com/user-attachments/assets/04121679-e6cc-4902-9085-96c330fa3cbc" />
